### PR TITLE
ignore coloring on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,7 @@ impl<'a> Colorize for &'a str {
 impl fmt::Display for ColoredString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 
-        if !self.has_colors() || self.is_plain() {
+        if cfg!(windows) || !self.has_colors() || self.is_plain()  {
             return (<String as fmt::Display>::fmt(&self.input, f))
         }
 


### PR DESCRIPTION
Ignores coloring cues on windows. This allows colored to be used cross platform without producing junk output on windows.
This could be removed when true windows support is figured out.
